### PR TITLE
Uncomment analytics include

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@
     <title>{{ page.title }}</title>
     <link rel="stylesheet" type="text/css" href="assets/css/custom.css">
 
-    {% comment %}{% include analytics.html %}{% endcomment %}
+    {% include analytics.html %}
   </head>
   <body>
 


### PR DESCRIPTION
The analytics include was commented out, which I didn't realise in my previous commit. This should add the tracking code to each page.